### PR TITLE
Use steam_link_msg in steam link result page

### DIFF
--- a/routes/views/accounts/get/linkSteam.js
+++ b/routes/views/accounts/get/linkSteam.js
@@ -14,14 +14,25 @@ exports = module.exports = function(req, res) {
 
 	if (req.query.steam_link_result) {
 		result = req.query.steam_link_result;
+		if (req.query.steam_link_msg) {
+			msg = req.query.steam_link_msg;
+		} else {
+			msg = null;
+		}
         var flash = {};
 		if (result == 'success') {
+			if (!msg) {
+				msg = 'Your steam account was successfully linked!';
+			}
 			flash.class = 'alert-success';
-			flash.messages = [{msg: 'Your steam account was successfully linked!'}];
+			flash.messages = [{msg: msg}];
 			flash.type = 'Success!';
 		} else {
+			if (!msg) {
+				msg = 'Your steam account was not successfully linked! Please verify you logged in correctly to steam and that your steam profile is public.';
+			}
 			flash.class = 'alert-danger';
-			flash.messages = [{msg: 'Your steam account was not successfully linked! Please verify you logged in correctly to steam.'}];
+			flash.messages = [{msg: msg}];
 			flash.type = 'Error!';
 		}
 	} else {

--- a/templates/views/account/linkSteam.pug
+++ b/templates/views/account/linkSteam.pug
@@ -10,7 +10,7 @@ block content
                 h4.account-subtitle.text-center By doing that, you will be able to run several accounts on the same computer, as long as all these accounts are also linked to Steam. The Steam account needs to have a copy of Forged Alliance. It doesn't need to be installed. The Steam account need to be public during the first login. You can set it back to private after the initial login. Be careful: If you try to log with a non-linked account on a computer that used a Steam-linked account, you will not be able to login! There is no going back! Once your account is tied to Steam, you can't unlink it!
                 hr
         .row
-            .col-md-offset-3.col-md-6
+            .col-md-12
                 +flash-messages(flash)
         .row
             a(href=steamConnect)


### PR DESCRIPTION
My faf-api PR https://github.com/FAForever/api/pull/164 adds a `steam_link_msg` parameter to the result redirect.

This website PR uses that parameter as the flash message if present.

TODO:
* [x] Fix flash display width

It would be nice if this didn't get linebroken: ![Screenshot](https://user-images.githubusercontent.com/611471/27007871-0d97ee76-4ea5-11e7-8d4b-94769fb46cd6.PNG) (Make flash box wider?)
