### PR TITLE
Fix string constant in ratingType comparison

### DIFF
--- a/public/js/app/leaderboards.js
+++ b/public/js/app/leaderboards.js
@@ -133,7 +133,7 @@ $(document).on('click', '.player', (function(){
   var name = $(this).data('name');
   var pastYear = moment().subtract(1, 'years').unix();
 
-  let featuredMod = ratingType === '1v1' ? 'ladder1v1' : 'faf';
+  let featuredMod = ratingType === 'ladder1v1' ? 'ladder1v1' : 'faf';
   $.ajax({
 		url: apiURL + '/data/gamePlayerStats?filter=player.id==' + id + ';game.featuredMod.technicalName=' + featuredMod + '&fields[gamePlayerStats]=afterMean,afterDeviation,scoreTime',
     success: function(result) {


### PR DESCRIPTION
ratingType is assigned a 'ladder1v1', not '1v1' value. Fixes wrong leaderboards being shown on the website at https://www.faforever.com/competitive/leaderboards/1v1.

(Ideally we should use constants for this, I guess?)