### PR TITLE
Revert "Fix client release crawler to grab stable python client versi…

### DIFF
--- a/scripts/getLatestClientRelease.js
+++ b/scripts/getLatestClientRelease.js
@@ -6,13 +6,8 @@ var date = new Date();
 
 module.exports.run = function run() {
 	//Get main client
-	gh.getRepo('faforever', 'client').listReleases(function(err, releases) {
+	gh.getRepo('faforever', 'client').getRelease('latest', function(err, release) {
 		if (!err) {
-			var release = getPythonClientStableRelease(releases);
-			if (release === null) {
-				console.log("No Python client stable version was found!");
-				return;
-			}
 			var data = {client_link: release.assets[0].browser_download_url};
 
 			//Get downlords client releases
@@ -44,18 +39,6 @@ module.exports.run = function run() {
 			verifyOutput();
 		}
 	});
-
-	function getPythonClientStableRelease(releases) {
-		for (var i = 0; i < releases.length ; i++) {
-			//FIXME - use some semver parser for this
-			var version = releases[i].tag_name;
-			var minor_version = parseInt(version.split(".")[1]);
-			var is_stable = minor_version % 2 === 0;
-			if (is_stable)
-				return releases[i];
-		}
-		return null;
-	}
 
 	function verifyOutput()
 	{


### PR DESCRIPTION
…ons"

The client has now switched to a semantic_version compatible scheme, and
the 'latest release' github endpoint will always point to a latest
stable release from now on.

This reverts commit 3e002bfb0ac8902cbcefe06bb0be5928949ea90e.