### PR TITLE
Change newshub text colour to match new blue client style

### DIFF
--- a/public/styles/site/newshub.sass
+++ b/public/styles/site/newshub.sass
@@ -1,3 +1,5 @@
+$headerColour: #6990e0
+  
 .newshub_container
   min-height: calc(100vh)
   background-color: #212121
@@ -10,7 +12,7 @@
 
 .newshub a
   text-decoration: none
-  color: rgb(24, 141, 129)
+  color: $headerColour
 .newshub h2
   font-family: 'Electrolize', sans-serif
 .newshub h3
@@ -120,12 +122,12 @@
 .article_hero h2:hover
   text-decoration: underline
 .article_hero h2
-  color: rgb(24, 141, 129)
+  color: $headerColour
   margin-top: 10px
   margin-bottom: 1px
   font-size: 30px
 .article_hero h3
-  color: rgb(24, 141, 129)
+  color: $headerColour
   margin-top: 4px
   margin-bottom: 2px
   font-size: 16px
@@ -178,7 +180,7 @@
 .article_column3
   margin-bottom: 10px
 .article_column3 a
-  color: rgb(24, 141, 129)
+  color: $headerColour
   display: block
   margin-left: 9px
 .article_column3 img 


### PR DESCRIPTION
The is turning blue at the same time as our green newshub goes out. Here is the fix

