### PR TITLE
Newshub open links in new tab

### DIFF
--- a/public/js/app/newshub.js
+++ b/public/js/app/newshub.js
@@ -9,13 +9,13 @@ $(document).ready(function() {
   $(".hoverable").click(function() {
 
     var url = $(this).attr("data-url");
-    if (typeof window.java !== 'undefined') 
-    {      
+    if (typeof window.java !== 'undefined')
+    {
       window.java.openUrl(url); // when hosted in java client, makes it launch in a new window
     }
     else
     {
-      window.location.href = url; // normal web browser change
+      window.open(url, "_blank"); // normal web browser change
     }
   });
 


### PR DESCRIPTION
I feel like this would be the expected behavior. Would also be nice if any links within the paragraph also got the `target="_blank"` attribute, but I have no idea how to do that with pug.