### PR TITLE
Update News Link on website to Newshub

### DIFF
--- a/templates/layouts/default.pug
+++ b/templates/layouts/default.pug
@@ -63,7 +63,7 @@ html
             ul.main-navigation
               li.mobile-nav-logo-wrapper: a(href="/", class="mobile-nav-logo")
                 img(src="/images/faf-logo.png")
-              li(class=(section == 'news' ? 'active' : null)): a(href='/news')
+              li(class=(section == 'news' ? 'active' : null)): a(href='/newshub')
                 i.fas.fa-rss
                 span News
               li(class=(section == 'competitive' ? 'active' : null)): a(href='/competitive/tournaments')


### PR DESCRIPTION
Change the Href to got to /newshub instead of /news people are missing out on all the stuff that is going on + on the /news page last post was Aug 2020