### PR TITLE
Remove Links to Outdated Twitter

### DIFF
--- a/templates/layouts/default.pug
+++ b/templates/layouts/default.pug
@@ -53,8 +53,6 @@ html
                 i.fab.fa-facebook-f
               li: a.icon(href="https://github.com/FAForever/")
                 i.fab.fa-github
-              li: a.icon(href="https://twitter.com/falliancef")
-                i.fab.fa-twitter
               li
                 form.nav-support-us(action='https://www.patreon.com/faf', method='get', target='_top')
                   button(type='submit', name='submit')
@@ -163,9 +161,6 @@ html
                   li
                     a(href="https://github.com/FAForever/" title="Follow Forged Alliance Forever on GitHub" target="_blank")
                       i.fab.fa-github
-                  li
-                    a(href="https://twitter.com/falliancef" title="Follow Forged Alliance Forever on Twitter" target="_blank")
-                      i.fab.fa-twitter
 
 
       //- JAVASCRIPT


### PR DESCRIPTION
Links to a Twitter account that inactive and that we don't have access too