### PR TITLE
Docker image: revert to previous lts version 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an ubuntu-image for building assets for use in a runtime image...
-FROM node:lts as builder
+FROM node:14 as builder
 
 RUN mkdir code
 
@@ -13,7 +13,7 @@ RUN yarn install
 RUN ./node_modules/.bin/grunt prod
 
 # Slimmer runtime image without python/make/gcc etc.
-FROM node:lts-alpine as runtime
+FROM node:14-alpine as runtime
 
 COPY --from=builder /code /code
 


### PR DESCRIPTION
This version is supported until early 2023.
We still need to fix the underlying issues in 2022.