### PR TITLE
Adding Open-Source License 

### DIFF
--- a/License.md
+++ b/License.md
@@ -1,0 +1,7 @@
+Copyright 2022 FAFOREVER
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
This is a Draft Pull Request to add an Open-Source License to the FAF Website so we can add 3rd party software to the repo to help with localization support for the website in multiple languages. Since the website was set up on GitHub there was no License set which stops us from being able to apply for Open-Source licenses from other companies.

To be able to add this MIT License to the Website I need approval from all Contributors to the website. This may take some time and the first person who says no to this PR then were unable to add a license to this repository.

All I need is for you to comment on this draft saying that you are okay with this License.

- [x] @Raistlfiren
- [x] @Blodir 
- [x] @Brutus5000 
- [x] @Sheeo 
- [x] @MrRowey 
- [x] @1-alex98 
- [x] @Rackover 
- [x] @FtXCommando 
- [ ] @lextoc 
- [ ] @duk3luk3 
- [x] @Sheikah45 
- [x] @Geosearchef 
- [x] @micheljung 
- [x] @dmitrii-badretdinov 
- [x] @Kazbek 
- [x] @Syldarion 
- [x] @JeroenDeDauw 
- [x] @norraxx 
- [x] @domis4 
- [x] @p4block 
- [x] @Viba 
- [x] @speed2CZ 
- [ ] @germanicianus 
- [ ] @EcoNooob 
- [x] @shalkya 
- [x] @IDragonfire 
- [ ] @jordan-schnur 
- [x] @anihilnine 
- [x] @Gatsik 
- [x] @NapMorax 
- [ ] @FlyingThunder 
- [x] @Askaholic 
- [ ] @VoRGoR 