### PR TITLE
Fix COC Link on registration Page (#2)

### DIFF
--- a/templates/mixins/form/account.pug
+++ b/templates/mixins/form/account.pug
@@ -71,7 +71,7 @@ mixin tosagree(checked)
             input(type='checkbox', name='privacyagree', required='required')
         label Agree to our Code of Conduct
           .input-group
-            p I have read and agree with out <a href=https://faforever.com/coc" rel="_new">Code of Conduct</a>
+            p I have read and agree with out <a href="https://faforever.com/coc" rel="_new">Code of Conduct</a>
             input(type='checkbox', name='cocagree', required='required')
 
 mixin gogUsername


### PR DESCRIPTION
Missing `"` at the beginning of the link to the COC