### PR TITLE
Flash Message Fix and client newshub

### DIFF
--- a/public/js/app/newshub.js
+++ b/public/js/app/newshub.js
@@ -58,3 +58,8 @@ function articleActivate(article) {
     });
 }
 
+let links = document.getElementsByTagName('a');
+let linksLength = links.length;
+for (let i= 0; i < linksLength; i++) {
+  links[i].target = '_blank';
+}

--- a/templates/mixins/flash-messages.pug
+++ b/templates/mixins/flash-messages.pug
@@ -3,7 +3,5 @@ mixin flash-messages(messages)
     div.alert(class=flash['class'])
       ul.flash-errors
         if flash.messages
-          if flash.messages[0].msg
+          if flash.messages[0].msg 
             li <strong>#{flash.type}</strong> !{flash.messages[0].msg}
-          if flash.messages[1].msg
-            li <strong>#{flash.type}</strong> !{flash.messages[1].msg}


### PR DESCRIPTION

Fix done in order to pass the faf test. Apparently the flash messages can break easily.


Small client newshub fix so it doesn't open browser links inside the client.