### PR TITLE
update github actions.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,39 @@
 name: Website Docker Release
 
 on: [ push, pull_request ]
-  
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
-
+  docker:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
-        
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v1.1.1
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ vars.DOCKER_ORG || 'faforever' }}/faf-website
+          flavor: latest=false
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - 
+        name: Build Docker Image
+        uses: docker/build-push-action@v5
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        if: ${{ github.ref_name == 'develop' || startsWith(github.ref, 'refs/tags') }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: faforever/faf-website
-          push: ${{ github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags') }}
-          tag_with_ref: true
+      -
+        name: Push Docker Image
+        uses: docker/build-push-action@v5
+        if: ${{ github.ref_name == 'develop' || startsWith(github.ref, 'refs/tags') }}
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
 closes #446

Some minor changes besides the update:
1. Images are now including labels (`docker inspect faforever/faf-website:develop`)
```
"Labels": {
                "org.opencontainers.image.created": "2023-11-07T20:09:31.934Z",
                "org.opencontainers.image.description": "FAForever's Website",
                "org.opencontainers.image.licenses": "MIT",
                "org.opencontainers.image.revision": "7a0e6f561a01a1a8f6194958209c6470b6458dac",
                "org.opencontainers.image.source": "https://github.com/fcaps/website",
                "org.opencontainers.image.title": "website",
                "org.opencontainers.image.url": "https://github.com/fcaps/website",
                "org.opencontainers.image.version": "develop"
            }
```
2. Concurrency disabled, actions run once for every PR, branch or tag
3. Option enabled to run this action also in the fork with `vars.DOCKER_ORG`
