### PR TITLE
Disable failing routes and cronjobs. part of #445

### DIFF
--- a/express.js
+++ b/express.js
@@ -105,6 +105,10 @@ const appGetRouteArray = [
 
 //Renders every page written above
 appGetRouteArray.forEach(page => app.get(`/${page}`, (req, res) => {
+  // disabled due https://github.com/FAForever/website/issues/445
+  if (['leaderboards', 'clans'].includes(page)) {
+    res.status(503).render('errors/503-known-issue')
+  }
   res.render(page);
 }));
 
@@ -145,17 +149,23 @@ const routes = './routes/views/';
 
 const clansRoutesGet = [
   'create', 'manage', 'accept_invite',];
-clansRoutesGet.forEach(page => app.get(`/clans/${page}`, loggedIn, require(`${routes}clans/get/${page}`)));
+// disabled due https://github.com/FAForever/website/issues/445
+// clansRoutesGet.forEach(page => app.get(`/clans/${page}`, loggedIn, require(`${routes}clans/get/${page}`)));
+clansRoutesGet.forEach(page => app.get(`/clans/${page}`, loggedIn, (req, res) =>  res.status(503).render('errors/503-known-issue')));
 
 const clansRoutesPost = [
   'create', 'destroy', 'invite', 'kick', 'transfer', 'update', 'leave', 'join',];
-clansRoutesPost.forEach(page => app.post(`/clans/${page}`, loggedIn, require(`${routes}clans/post/${page}`)));
+// disabled due https://github.com/FAForever/website/issues/445
+// clansRoutesPost.forEach(page => app.post(`/clans/${page}`, loggedIn, require(`${routes}clans/post/${page}`)));
+clansRoutesPost.forEach(page => app.post(`/clans/${page}`, loggedIn,  (req, res) =>  res.status(503).render('errors/503-known-issue')));
 
 
+// disabled due https://github.com/FAForever/website/issues/445
 //When searching for a specific clan
-app.get('/clans/*', (req, res) => {
-  res.render(`clans/seeClan`);
-});
+// app.get('/clans/*', (req, res) => {
+//   res.render(`clans/seeClan`);
+// });
+app.get('/clans/*',  (req, res) =>  res.status(503).render('errors/503-known-issue'));
 
 
 // Markdown Routes

--- a/public/js/app/index.js
+++ b/public/js/app/index.js
@@ -6,5 +6,7 @@ async function playerCounterJSON() {
 
 playerCounterJSON()
   .then((data) => {
-    document.getElementById('playerCounter').insertAdjacentHTML("afterbegin", data.length);
+    // disabled due https://github.com/FAForever/website/issues/445
+    // document.getElementById('playerCounter').insertAdjacentHTML("afterbegin", data.length);
+    document.getElementById('playerCounter').insertAdjacentHTML("afterbegin", "MANY");
   });

--- a/scripts/extractor.js
+++ b/scripts/extractor.js
@@ -143,60 +143,65 @@ async function contentCreators() {
 }
 
 async function getAllClans() {
-  try {
-    let response = await axios.get(`${process.env.API_URL}/data/clan?sort=createTime&include=leader&fields[clan]=name,tag,description,leader,memberships,createTime&fields[player]=login&page[number]=1&page[size]=3000`);
-    
-    let dataObjectToArray = Object.values(response.data);
-    let clanLeader = dataObjectToArray[2].map(item => ({
-      leaderName: item.attributes.login
-    }));
-    let clanValues = dataObjectToArray[0].map(item => ({
-      //id: item.id,
-      name: item.attributes.name,
-      tag: item.attributes.tag,
-      createTime: item.attributes.createTime,
-      //description: item.attributes.description,
-      population: item.relationships.memberships.data.length
-    }));
-    const combineArrays = (array1, array2) => array1.map((x, i) => [x, array2[i]]);
-    let clanData = combineArrays(clanLeader, clanValues);
-    clanData.sort((playerA, playerB) => playerA[1].population - playerB[1].population);
-    return await clanData;
-
-  } catch (e) {
-    console.log(e);
-    return null;
-  }
+  
+  return [];
+  //disabled due https://github.com/FAForever/website/issues/445
+  // try {
+  //   let response = await axios.get(`${process.env.API_URL}/data/clan?sort=createTime&include=leader&fields[clan]=name,tag,description,leader,memberships,createTime&fields[player]=login&page[number]=1&page[size]=3000`);
+  //  
+  //   let dataObjectToArray = Object.values(response.data);
+  //   let clanLeader = dataObjectToArray[2].map(item => ({
+  //     leaderName: item.attributes.login
+  //   }));
+  //   let clanValues = dataObjectToArray[0].map(item => ({
+  //     //id: item.id,
+  //     name: item.attributes.name,
+  //     tag: item.attributes.tag,
+  //     createTime: item.attributes.createTime,
+  //     //description: item.attributes.description,
+  //     population: item.relationships.memberships.data.length
+  //   }));
+  //   const combineArrays = (array1, array2) => array1.map((x, i) => [x, array2[i]]);
+  //   let clanData = combineArrays(clanLeader, clanValues);
+  //   clanData.sort((playerA, playerB) => playerA[1].population - playerB[1].population);
+  //   return await clanData;
+  //
+  // } catch (e) {
+  //   console.log(e);
+  //   return null;
+  // }
 
 }
 
 
 async function getLeaderboards(leaderboardID) {
-  try {
-    let response = await axios.get(`${process.env.API_URL}/data/leaderboardRating?include=player&sort=-rating&filter=leaderboard.id==${leaderboardID};updateTime=ge=${currentDate}&page[size]=9999`);
-
-
-    let dataObjectToArray = await Object.values(response.data);
-
-    let playerLogin = dataObjectToArray[2].map(item => ({
-      label: item.attributes.login
-    }));
-    let playerValues = dataObjectToArray[0].map(item => ({
-      rating: item.attributes.rating,
-      totalgames: item.attributes.totalGames,
-      wonGames: item.attributes.wonGames,
-      date: item.attributes.updateTime,
-    }));
-    const combineArrays = (array1, array2) => array1.map((x, i) => [x, array2[i]]);
-    let leaderboardData = combineArrays(playerLogin, playerValues);
-    leaderboardData.sort((playerA, playerB) =>  playerB[1].rating - playerA[1].rating);
-    return await leaderboardData;
-    
-  } catch (e) {
-    console.log(e);
-    return null;
-
-  }
+  return [];
+  //disabled due https://github.com/FAForever/website/issues/445
+  // try {
+  //   let response = await axios.get(`${process.env.API_URL}/data/leaderboardRating?include=player&sort=-rating&filter=leaderboard.id==${leaderboardID};updateTime=ge=${currentDate}&page[size]=9999`);
+  //
+  //
+  //   let dataObjectToArray = await Object.values(response.data);
+  //
+  //   let playerLogin = dataObjectToArray[2].map(item => ({
+  //     label: item.attributes.login
+  //   }));
+  //   let playerValues = dataObjectToArray[0].map(item => ({
+  //     rating: item.attributes.rating,
+  //     totalgames: item.attributes.totalGames,
+  //     wonGames: item.attributes.wonGames,
+  //     date: item.attributes.updateTime,
+  //   }));
+  //   const combineArrays = (array1, array2) => array1.map((x, i) => [x, array2[i]]);
+  //   let leaderboardData = combineArrays(playerLogin, playerValues);
+  //   leaderboardData.sort((playerA, playerB) =>  playerB[1].rating - playerA[1].rating);
+  //   return await leaderboardData;
+  //  
+  // } catch (e) {
+  //   console.log(e);
+  //   return null;
+  //
+  // }
 }
 
 module.exports.run = function run() {

--- a/scripts/getRecentUsers.js
+++ b/scripts/getRecentUsers.js
@@ -13,20 +13,21 @@ let currentDate = new Date(minusTimeFilter).toISOString();
 
 async function getRecentUsers() {
   
-  try {
-    let response = await fetch(`${process.env.API_URL}/data/leaderboardRating?filter=updateTime=gt=${currentDate}&page[size]=5000`);
-    let fetchData = await response.json();
-    //Now we get a js array rather than a js object. Otherwise we can't sort it out.
-    let dataObjectToArray = Object.values(fetchData);
-    let data = dataObjectToArray[0].map((item)=> ({
-      playerID: item.id
-    }));
-    return await data;    
-  }catch (e) {
-    console.log(e);
-    return null;
-  }
-
+  return []
+  // disabled due https://github.com/FAForever/website/issues/445
+  // try {
+  //   let response = await fetch(`${process.env.API_URL}/data/leaderboardRating?filter=updateTime=gt=${currentDate}&page[size]=5000`);
+  //   let fetchData = await response.json();
+  //   //Now we get a js array rather than a js object. Otherwise we can't sort it out.
+  //   let dataObjectToArray = Object.values(fetchData);
+  //   let data = dataObjectToArray[0].map((item)=> ({
+  //     playerID: item.id
+  //   }));
+  //   return await data;    
+  // }catch (e) {
+  //   console.log(e);
+  //   return null;
+  // }
 }
 
 module.exports.run = function run() {

--- a/templates/views/errors/503-known-issue.pug
+++ b/templates/views/errors/503-known-issue.pug
@@ -1,0 +1,8 @@
+extends ../../layouts/default
+block bannerData
+  - var bannerImage = "tutorial"
+  - var bannerFirstTitle = "Temporarily Disabled"
+  - var bannerSecondTitle = ""
+  - var bannerSubTitle = "Sorry commanders, we failed to build enough pgens and are now in a tech upgrade"
+block content
+


### PR DESCRIPTION
All routes for clan and leaderboard are disabled with a new 503 view:
The links are still there, but will lead to this page.
<img width="1172" alt="image" src="https://github.com/FAForever/website/assets/48691346/588a07cc-44c0-4226-a950-09309d66b9ad">
