### PR TITLE
added missing return

### DIFF
--- a/express.js
+++ b/express.js
@@ -108,7 +108,7 @@ const appGetRouteArray = [
 appGetRouteArray.forEach(page => app.get(`/${page}`, (req, res) => {
   // disabled due https://github.com/FAForever/website/issues/445
   if (['leaderboards', 'clans'].includes(page)) {
-    res.status(503).render('errors/503-known-issue')
+    return res.status(503).render('errors/503-known-issue')
   }
   res.render(page);
 }));


### PR DESCRIPTION
to fix issues like this:
```
website-website-1  |     [error] Incoming request to" /clans "failed with error " Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client "
website-website-1  |     Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
website-website-1  |         at new NodeError (node:internal/errors:406:5)
website-website-1  |         at ServerResponse.setHeader (node:_http_outgoing:652:11)
website-website-1  |         at ServerResponse.header (/code/node_modules/express/lib/response.js:794:10)
website-website-1  |         at ServerResponse.send (/code/node_modules/express/lib/response.js:174:12)
website-website-1  |         at done (/code/node_modules/express/lib/response.js:1035:10)
website-website-1  |         at exports.renderFile (/code/node_modules/pug/lib/index.js:448:12)
website-website-1  |         at exports.__express [as engine] (/code/node_modules/pug/lib/index.js:493:11)
website-website-1  |         at View.render (/code/node_modules/express/lib/view.js:135:8)
website-website-1  |         at tryRender (/code/node_modules/express/lib/application.js:657:10)
website-website-1  |         at Function.render (/code/node_modules/express/lib/application.js:609:3)
```
 