### PR TITLE
increased ttl to relax #482

### DIFF
--- a/lib/LeaderboardService.js
+++ b/lib/LeaderboardService.js
@@ -1,4 +1,4 @@
-const leaderboardTTL = 60 * 60 * 4 // 4 hours ttl as a relaxation for https://github.com/FAForever/website/issues/482
+const leaderboardTTL = 60 * 60  // 1 hours ttl as a relaxation for https://github.com/FAForever/website/issues/482
 
 class LeaderboardService {
     constructor(cacheService, mutexService, leaderboardRepository, lockTimeout = 3000) {

--- a/lib/LeaderboardService.js
+++ b/lib/LeaderboardService.js
@@ -1,3 +1,5 @@
+const leaderboardTTL = 60 * 60 * 4 // 4 hours ttl as a relaxation for https://github.com/FAForever/website/issues/482
+
 class LeaderboardService {
     constructor(cacheService, mutexService, leaderboardRepository, lockTimeout = 3000) {
         this.lockTimeout = lockTimeout
@@ -26,7 +28,7 @@ class LeaderboardService {
 
         await this.mutexService.acquire(async () => {
             const result = await this.leaderboardRepository.fetchLeaderboard(id)
-            this.cacheService.set(cacheKey, result);
+            this.cacheService.set(cacheKey, result, leaderboardTTL);
         })
 
         return this.getLeaderboard(id)

--- a/tests/LeaderboardService.test.js
+++ b/tests/LeaderboardService.test.js
@@ -122,7 +122,7 @@ test('full scenario', async () => {
     expect(cacheSetSpy).toHaveBeenCalledTimes(1);
     
     const date = new Date()
-    date.setSeconds(date.getSeconds() + 301)
+    date.setSeconds(date.getSeconds() + (60 * 60 * 4) + 1)
     jest.setSystemTime(date);
     
     // start another with when the cache is stale

--- a/tests/LeaderboardService.test.js
+++ b/tests/LeaderboardService.test.js
@@ -122,7 +122,7 @@ test('full scenario', async () => {
     expect(cacheSetSpy).toHaveBeenCalledTimes(1);
     
     const date = new Date()
-    date.setSeconds(date.getSeconds() + (60 * 60 * 4) + 1)
+    date.setSeconds(date.getSeconds() + (60 * 60) + 1)
     jest.setSystemTime(date);
     
     // start another with when the cache is stale


### PR DESCRIPTION
related #482 

4 hours cache is better than having an unresponsive leader board.
change my mind