### PR TITLE
Clan cache warmup #520

### DIFF
--- a/src/backend/AppKernel.js
+++ b/src/backend/AppKernel.js
@@ -20,6 +20,7 @@ const leaderboardRouter = require('./routes/views/leaderboardRouter')
 const clanRouter = require('./routes/views/clanRouter')
 const accountRouter = require('./routes/views/accountRouter')
 const dataRouter = require('./routes/views/dataRouter')
+const { CacheService } = require('./services/CacheService')
 
 class AppKernel {
     constructor (nodeEnv = 'production') {
@@ -124,6 +125,7 @@ class AppKernel {
         this.schedulers.push(leaderboardCacheCrawler(this.appContainer.get('LeaderboardService')))
         this.schedulers.push(wordpressCacheCrawler(this.appContainer.get('WordpressService')))
         this.schedulers.push(clanCacheCrawler(this.appContainer.get('ClanService')))
+        console.log(CacheService.getStats().keys)
     }
 
     loadControllers () {

--- a/src/backend/AppKernel.js
+++ b/src/backend/AppKernel.js
@@ -20,7 +20,6 @@ const leaderboardRouter = require('./routes/views/leaderboardRouter')
 const clanRouter = require('./routes/views/clanRouter')
 const accountRouter = require('./routes/views/accountRouter')
 const dataRouter = require('./routes/views/dataRouter')
-const { CacheService } = require('./services/CacheService')
 
 class AppKernel {
     constructor (nodeEnv = 'production') {
@@ -125,7 +124,6 @@ class AppKernel {
         this.schedulers.push(leaderboardCacheCrawler(this.appContainer.get('LeaderboardService')))
         this.schedulers.push(wordpressCacheCrawler(this.appContainer.get('WordpressService')))
         this.schedulers.push(clanCacheCrawler(this.appContainer.get('ClanService')))
-        console.log(CacheService.getStats().keys)
     }
 
     loadControllers () {

--- a/src/backend/AppKernel.js
+++ b/src/backend/AppKernel.js
@@ -11,6 +11,7 @@ const flash = require('connect-flash')
 const FileStore = require('session-file-store')(session)
 const wordpressCacheCrawler = require('./cron-jobs/wordpressCacheCrawler')
 const leaderboardCacheCrawler = require('./cron-jobs/leaderboardCacheCrawler')
+const clanCacheCrawler = require('./cron-jobs/clanCacheCrawler')
 const defaultRouter = require('./routes/views/defaultRouter')
 const authRouter = require('./routes/views/auth')
 const staticMarkdownRouter = require('./routes/views/staticMarkdownRouter')
@@ -19,7 +20,6 @@ const leaderboardRouter = require('./routes/views/leaderboardRouter')
 const clanRouter = require('./routes/views/clanRouter')
 const accountRouter = require('./routes/views/accountRouter')
 const dataRouter = require('./routes/views/dataRouter')
-const clanCacheCrawler = require('./cron-jobs/clanCacheCrawler')
 
 class AppKernel {
     constructor (nodeEnv = 'production') {

--- a/src/backend/AppKernel.js
+++ b/src/backend/AppKernel.js
@@ -19,6 +19,7 @@ const leaderboardRouter = require('./routes/views/leaderboardRouter')
 const clanRouter = require('./routes/views/clanRouter')
 const accountRouter = require('./routes/views/accountRouter')
 const dataRouter = require('./routes/views/dataRouter')
+const clanCacheCrawler = require('./cron-jobs/clanCacheCrawler')
 
 class AppKernel {
     constructor (nodeEnv = 'production') {
@@ -122,6 +123,7 @@ class AppKernel {
     startCronJobs () {
         this.schedulers.push(leaderboardCacheCrawler(this.appContainer.get('LeaderboardService')))
         this.schedulers.push(wordpressCacheCrawler(this.appContainer.get('WordpressService')))
+        this.schedulers.push(clanCacheCrawler(this.appContainer.get('ClanService')))
     }
 
     loadControllers () {

--- a/src/backend/cron-jobs/clanCacheCrawler.js
+++ b/src/backend/cron-jobs/clanCacheCrawler.js
@@ -10,7 +10,7 @@ const errorHandler = (e, name) => {
 
 const warmupClans = async (clanService) => {
     try {
-        await clanService.getAll(false)
+        await clanService.getAll(true)
             .then(() => successHandler('clanService::getAll(global)'))
             .catch((e) => errorHandler(e, 'clanService::getAll(global)'))
     } catch (e) {
@@ -27,7 +27,7 @@ const warmupClans = async (clanService) => {
 module.exports = (clanService) => {
     warmupClans(clanService).then(() => {})
 
-    const clansScheduler = new Scheduler('createClanCache',
+    const clansScheduler = new Scheduler('createClanCache', // Refresh cache every 59 minutes
         () => warmupClans(clanService).then(() => {}), 60 * 59 * 1000)
     clansScheduler.start()
 

--- a/src/backend/cron-jobs/clanCacheCrawler.js
+++ b/src/backend/cron-jobs/clanCacheCrawler.js
@@ -1,0 +1,35 @@
+const Scheduler = require('../services/Scheduler')
+
+const successHandler = (name) => {
+    console.debug('[debug] Cache updated', { name })
+}
+const errorHandler = (e, name) => {
+    console.error(e.toString(), { name, entrypoint: 'clanCacheCrawler.js' })
+    console.error(e.stack)
+}
+
+const warmupClans = async (clanService) => {
+    try {
+        await clanService.getAll(false)
+            .then(() => successHandler('clanService::getAll(global)'))
+            .catch((e) => errorHandler(e, 'clanService::getAll(global)'))
+    } catch (e) {
+        console.error('Error: clanCacheCrawler::warmupClans failed with "' + e.toString() + '"',
+            { entrypoint: 'clanCacheCrawler.js' })
+        console.error(e.stack)
+    }
+}
+
+/**
+ * @param {clanService} clanService
+ * @return {Scheduler[]}
+ */
+module.exports = (clanService) => {
+    warmupClans(clanService).then(() => {})
+
+    const clansScheduler = new Scheduler('createClanCache',
+        () => warmupClans(clanService).then(() => {}), 60 * 59 * 1000)
+    clansScheduler.start()
+
+    return clansScheduler
+}

--- a/src/backend/cron-jobs/leaderboardCacheCrawler.js
+++ b/src/backend/cron-jobs/leaderboardCacheCrawler.js
@@ -38,7 +38,8 @@ const warmupLeaderboard = async (leaderboardService) => {
 module.exports = (leaderboardService) => {
     warmupLeaderboard(leaderboardService).then(() => {})
 
-    const leaderboardScheduler = new Scheduler('createLeaderboardCaches', () => warmupLeaderboard(leaderboardService).then(() => {}), 60 * 59 * 1000)
+    const leaderboardScheduler = new Scheduler('createLeaderboardCaches',
+        () => warmupLeaderboard(leaderboardService).then(() => {}), 60 * 59 * 1000)
     leaderboardScheduler.start()
 
     return leaderboardScheduler

--- a/src/backend/cron-jobs/wordpressCacheCrawler.js
+++ b/src/backend/cron-jobs/wordpressCacheCrawler.js
@@ -40,10 +40,11 @@ const warmupWordpressCache = (wordpressService) => {
  * @param {LeaderboardService} leaderboardService
  * @return {Scheduler[]}
  */
-module.exports = (wordpressService, leaderboardService) => {
+module.exports = (wordpressService) => {
     warmupWordpressCache(wordpressService)
 
-    const wordpressScheduler = new Scheduler('createWordpressCaches', () => warmupWordpressCache(wordpressService), 60 * 59 * 1000)
+    const wordpressScheduler = new Scheduler('createWordpressCaches',
+        () => warmupWordpressCache(wordpressService), 60 * 59 * 1000)
     wordpressScheduler.start()
 
     return wordpressScheduler

--- a/src/backend/cron-jobs/wordpressCacheCrawler.js
+++ b/src/backend/cron-jobs/wordpressCacheCrawler.js
@@ -37,7 +37,6 @@ const warmupWordpressCache = (wordpressService) => {
 
 /**
  * @param {WordpressService} wordpressService
- * @param {LeaderboardService} leaderboardService
  * @return {Scheduler[]}
  */
 module.exports = (wordpressService) => {

--- a/src/backend/services/CacheService.js
+++ b/src/backend/services/CacheService.js
@@ -1,9 +1,12 @@
 const NodeCache = require('node-cache')
-const cacheService = new NodeCache(
-    {
-        stdTTL: 300, // use 5 min for all caches if not changed with ttl
-        checkperiod: 600 // cleanup memory every 10 min
-    }
-)
 
-module.exports.CacheService = cacheService
+const createCacheService = (stdTTL, checkperiod) => {
+    return new NodeCache({
+        stdTTL: stdTTL || 300,
+        checkperiod: checkperiod || 600
+    })
+}
+
+module.exports = {
+    CacheService: createCacheService()
+}

--- a/src/backend/services/CacheService.js
+++ b/src/backend/services/CacheService.js
@@ -1,12 +1,9 @@
 const NodeCache = require('node-cache')
+const cacheService = new NodeCache(
+    {
+        stdTTL: 300, // use 5 min for all caches if not changed with ttl
+        checkperiod: 600 // cleanup memory every 10 min
+    }
+)
 
-const createCacheService = (stdTTL, checkperiod) => {
-    return new NodeCache({
-        stdTTL: stdTTL || 300,
-        checkperiod: checkperiod || 600
-    })
-}
-
-module.exports = {
-    CacheService: createCacheService()
-}
+module.exports.CacheService = cacheService

--- a/src/backend/services/ClanService.js
+++ b/src/backend/services/ClanService.js
@@ -1,5 +1,5 @@
 const { MutexService } = require('./MutexService')
-const clanTTL = 60 * 5
+const clanTTL = 60 * 60
 
 class ClanService {
     constructor (cacheService, dataRepository, lockTimeout = 3000) {


### PR DESCRIPTION
Address #520 for the most part.

## Criteria:
*cache will be generated at server start/restart*

- Runs on start along with other jobs

*will be scheduled to refresh it every (ttl - 1min), currently this would be 59min*

- TTL configured is 60 min in clanService - job runs every 59

*should not run in parallel with other JavaApi calls if possible (ddos ourself if the list of crawlers getting bigger)*

- I believe mutex takes care of this here:
```
from src/backend/services/clanService.js

if (this.mutexService.locked) {
        await this.mutexService.acquire(() => {
        }, this.lockTimeout)
    return this.getAll()
}
```
*should not crash the server if the JavaApi is not reachable or and exception is happening.*

- Exceptions are handled the same way as leaderboards with logging and catching

*should log if a cache was getting refreshed or when something failed*

- Error handler and success handler print when caches updates/fails.
