### PR TITLE
Clan update and create message validations

### DIFF
--- a/public/styles/abstracts/_mixins.sass
+++ b/public/styles/abstracts/_mixins.sass
@@ -95,7 +95,11 @@ button
   font-size: 0.75em
   margin: 0.25em
   padding: 0.5em
-  
+.bigButton
+  @include button
+  font-size: 1em
+  margin: 0.75em
+  padding: 1em
 .descriptionMain
   //background-color: variables.$background-secondary
   padding: 10px

--- a/src/backend/routes/views/clans/create.js
+++ b/src/backend/routes/views/clans/create.js
@@ -8,9 +8,10 @@ module.exports = [
     )
         .notEmpty()
         .isLength({ max: 3 }),
-    body('clan_description', 'Please add a description for your clan')
-        .notEmpty()
-        .isLength({ max: 1000 }),
+    body('clan_description', 'Cannot exceed 1000 characters').isLength({
+        max: 1000,
+    }),
+    body('clan_description', 'Cannot be empty').notEmpty(),
     body('clan_name', "Please indicate your clan's name")
         .notEmpty()
         .isLength({ max: 40 }),

--- a/src/backend/routes/views/clans/post/update.js
+++ b/src/backend/routes/views/clans/post/update.js
@@ -8,9 +8,10 @@ exports = module.exports = [
     )
         .notEmpty()
         .isLength({ max: 3 }),
-    body('clan_description', 'Please add a description for your clan')
-        .notEmpty()
-        .isLength({ max: 1000 }),
+    body('clan_description', 'Cannot exceed 1000 characters').isLength({
+        max: 1000,
+    }),
+    body('clan_description', 'Cannot be empty').notEmpty(),
     body('clan_name', "Please indicate your clan's name")
         .notEmpty()
         .isLength({ max: 40 }),

--- a/src/backend/templates/views/clans/create.pug
+++ b/src/backend/templates/views/clans/create.pug
@@ -50,7 +50,7 @@ block content
                         name='clan_description',
                         title='description',
                         required='required',
-                        placeholder='The description players will see when they look your clan'
+                        placeholder='The description players will see when they view your clan'
                     ) #{ clan_description }
                     br
 

--- a/src/backend/templates/views/clans/create.pug
+++ b/src/backend/templates/views/clans/create.pug
@@ -54,4 +54,4 @@ block content
                     ) #{ clan_description }
                     br
 
-                    button.bigButton(type='submit') Create your Clan
+                    button.bigButton(type='submit') Create Your Clan

--- a/src/backend/templates/views/clans/manage.pug
+++ b/src/backend/templates/views/clans/manage.pug
@@ -41,7 +41,7 @@ block content
                 ) #{ clan_description }
                 br
 
-                button(type='submit') Update Clan Settings
+                button.bigButton(type='submit') Update Clan Settings
                 br
                 br
                 hr

--- a/src/backend/templates/views/clans/manage.pug
+++ b/src/backend/templates/views/clans/manage.pug
@@ -56,5 +56,5 @@ block content
                 action='/clans/destroy',
                 onsubmit='return confirm(\'THIS OPERATION IS DEFINITIVE. Press OK to confirm you want to delete your clan\');'
             )
-                button(type='submit') Delete my clan
+                button(type='submit') Delete My Clan
             br

--- a/src/backend/templates/views/clans/manage.pug
+++ b/src/backend/templates/views/clans/manage.pug
@@ -37,7 +37,7 @@ block content
                     name='clan_description',
                     title='description',
                     required='required',
-                    placeholder='The description players will see when they look your clan'
+                    placeholder='The description players will see when they view your clan'
                 ) #{ clan_description }
                 br
 


### PR DESCRIPTION
# Edit error messages for clan creation/updating to address #528
We may not need the error regarding an empty descriptions as:
```                    
title='description',
required='required',
```
Handles empty for us natively but there no harm in maintaining both errors.
## Also included 
- Some styling for the buttons to create and update the clan (see images)
    -  Re-add unusused class
    -  apply same class to the update button (see screenshots - mostly a top margin change)
- English change on clan description
    - `The description players will see when they look your clan`  
    - Becomes: `The description players will see when they view your clan`
    
Before:                                     
![Screenshot 2023-12-14 at 15 49 09](https://github.com/FAForever/website/assets/50498548/1a675dc9-e8fa-4580-8e23-ccfbaec33f2b)    
After:
![Screenshot 2023-12-14 at 15 49 50](https://github.com/FAForever/website/assets/50498548/441eadfa-9bef-44bd-809c-3f53dea2c86d)

    
 

