### PR TITLE
Addition - Secondary account disclaimer

### DIFF
--- a/src/backend/AppKernel.js
+++ b/src/backend/AppKernel.js
@@ -45,7 +45,8 @@ class AppKernel {
 
     bootstrapExpress() {
         this.expressApp = express()
-
+        this.expressApp.locals.discordUrl = 'https://discord.gg/mXahVSKGVb'
+        this.expressApp.locals.forumUrl = 'https://forum.faforever.com/'
         this.expressApp.locals.clanInvitations = {}
         this.expressApp.use((req, res, next) => {
             res.locals.navLinks = []

--- a/src/backend/templates/layouts/default.pug
+++ b/src/backend/templates/layouts/default.pug
@@ -57,11 +57,11 @@ html(lang='en')
             .topNavContainer
                 a.topnav_item(href='/donation') Support FAF
             .topNavContainer
-                a.topnav_item(href='https://forum.faforever.com/') Forums
+                a.topnav_item(href=forumUrl) Forums
             .topNavContainer
                 a.topnav_item(href='https://wiki.faforever.com/en/home') Wiki
             .topNavContainer
-                a(href='https://discord.gg/mXahVSKGVb')
+                a(href=discordUrl)
                     img(src='/images/fontAwesomeIcons/discord.svg')
             .topNavContainer
                 a(href='https://www.youtube.com/c/ForgedAllianceForever')
@@ -211,7 +211,7 @@ html(lang='en')
                         a(href='/logout') Log Out
 
                 .mobileSocialMedia
-                    a(href='https://discord.gg/mXahVSKGVb')
+                    a(href=discordUrl)
                         img(src='/images/fontAwesomeIcons/discord.svg')
                     a(href='https://www.twitch.tv/faflive')
                         img(src='/images/fontAwesomeIcons/twitch.svg')
@@ -220,7 +220,7 @@ html(lang='en')
                     a(href='https://github.com/FAForever')
                         img(src='/images/fontAwesomeIcons/github.svg')
                 .mobileOtherLinks
-                    a(href='https://forum.faforever.com/') Forums
+                    a(href=forumUrl) Forums
                     a(href='https://wiki.faforever.com/en/home') FAF Wiki
             .splatForgedBorder.transformationReverse.absoluteBottom
                 .movingBackground1
@@ -288,9 +288,9 @@ html(lang='en')
 
                     ul CONTACT US
                         li
-                            a(href='https://discord.gg/mXahVSKGVb') DISCORD
+                            a(href=discordUrl) DISCORD
                         li
-                            a(href='https://forum.faforever.com/') FORUMS
+                            a(href=forumUrl) FORUMS
 
             script(src=webpackAssetJS('navigation'))
             script(

--- a/src/backend/templates/views/account/register.pug
+++ b/src/backend/templates/views/account/register.pug
@@ -20,7 +20,7 @@ block content
                             href='/account/requestPasswordReset',
                             target='_blank'
                         ) Lost Account or Returning Player
-                p Creating and operating multiple accounts is prohibited.
+                    p Creating and operating multiple accounts is prohibited.
                 form(
                     method='post',
                     action='/account/register',

--- a/src/backend/templates/views/account/register.pug
+++ b/src/backend/templates/views/account/register.pug
@@ -16,11 +16,15 @@ block content
                 hr
                 h3 Lost account / returning player
                 p If you have a FAF account you can no longer access, please attempt to &nbsp
-                  a(href="https://help.steampowered.com/en/wizard/HelpWithLoginInfo?reset=1&issueid=408" target="_blank") reset your Steam password.
-                  | &nbspFor further assistance, contact the moderation team via&nbsp
-                  a(href=discordUrl target="_blank") Discord
-                  |  or the&nbsp
-                  a(href=forumUrl target="_blank") Forums.
+                    a(
+                        href='https://help.steampowered.com/en/wizard/HelpWithLoginInfo?reset=1&issueid=408',
+                        target='_blank'
+                    ) reset your Steam password.
+                    | &nbspFor further assistance, contact the moderation team via&nbsp
+                    a(href=discordUrl, target='_blank') Discord
+                    |
+                    | or the&nbsp
+                    a(href=forumUrl, target='_blank') Forums.
                 p Creating and operating multiple accounts is prohibited, and creating a secondary account will lead to moderation action.
                 form(
                     method='post',

--- a/src/backend/templates/views/account/register.pug
+++ b/src/backend/templates/views/account/register.pug
@@ -13,7 +13,6 @@ block content
                 br
                 +flash-messages(flash)
 
-                hr
                 h3
                     strong
                         a(

--- a/src/backend/templates/views/account/register.pug
+++ b/src/backend/templates/views/account/register.pug
@@ -15,17 +15,17 @@ block content
 
                 hr
                 h3 Lost account / returning player
+                p Creating and operating multiple accounts is prohibited.
                 p If you have a FAF account you can no longer access, please attempt to &nbsp
                     a(
                         href='https://help.steampowered.com/en/wizard/HelpWithLoginInfo?reset=1&issueid=408',
                         target='_blank'
                     ) reset your Steam password.
-                    | &nbspFor further assistance, contact the moderation team via&nbsp
+                p For further assistance, contact the moderation team via&nbsp;
                     a(href=discordUrl, target='_blank') Discord
                     |
-                    | or the&nbsp
+                    | or the&nbsp;
                     a(href=forumUrl, target='_blank') Forums.
-                p Creating and operating multiple accounts is prohibited, and creating a secondary account will lead to moderation action.
                 form(
                     method='post',
                     action='/account/register',

--- a/src/backend/templates/views/account/register.pug
+++ b/src/backend/templates/views/account/register.pug
@@ -12,10 +12,10 @@ block content
                 h2 Welcome to the FAF community
                 br
                 +flash-messages(flash)
-                    br
+
                 hr
-                    h3 Lost account / returning player
-                    p If you previously had a FAF account you no longer can get access to, please contact the moderation team via discord or forums, or see if you can reset your password using the Steam API. Note that creating and operating multiple accounts is prohibited, and creating a secondary account could lead to moderation action.
+                h3 Lost account / returning player
+                p If you previously had a FAF account you no longer can get access to, please contact the moderation team via discord or forums, or see if you can reset your password using the Steam API. Note that creating and operating multiple accounts is prohibited, and creating a secondary account could lead to moderation action.
 
                 form(
                     method='post',

--- a/src/backend/templates/views/account/register.pug
+++ b/src/backend/templates/views/account/register.pug
@@ -14,7 +14,8 @@ block content
                 +flash-messages(flash)
 
                 hr
-                h3 Lost account / returning player
+                h3
+                    strong Lost account / returning player
                 p Creating and operating multiple accounts is prohibited.
                 p If you have a FAF account you can no longer access, please attempt to &nbsp
                     a(

--- a/src/backend/templates/views/account/register.pug
+++ b/src/backend/templates/views/account/register.pug
@@ -15,23 +15,19 @@ block content
 
                 hr
                 h3
-                    strong Lost account / returning player
+                    strong
+                        a(
+                            href='/account/requestPasswordReset',
+                            target='_blank'
+                        ) Lost Account or Returning Player
                 p Creating and operating multiple accounts is prohibited.
-                p If you have a FAF account you can no longer access, please attempt to&nbsp;
-                    a(
-                        href='https://help.steampowered.com/en/wizard/HelpWithLoginInfo?reset=1&issueid=408',
-                        target='_blank'
-                    ) reset your Steam password.
-                p For further assistance, contact the moderation team via&nbsp;
-                    a(href=discordUrl, target='_blank') Discord
-                    |
-                    | or the&nbsp;
-                    a(href=forumUrl, target='_blank') Forums.
                 form(
                     method='post',
                     action='/account/register',
                     data-toggle='validator'
                 )
+                    h2
+                        strong New Players
                     +username
                     br
                     br

--- a/src/backend/templates/views/account/register.pug
+++ b/src/backend/templates/views/account/register.pug
@@ -12,7 +12,7 @@ block content
                 h2 Welcome to the FAF community
                 br
                 +flash-messages(flash)
-                                br
+                    br
                 hr
                     h3 Lost account / returning player
                     p If you previously had a FAF account you no longer can get access to, please contact the moderation team via discord or forums, or see if you can reset your password using the Steam API. Note that creating and operating multiple accounts is prohibited, and creating a secondary account could lead to moderation action.

--- a/src/backend/templates/views/account/register.pug
+++ b/src/backend/templates/views/account/register.pug
@@ -17,7 +17,7 @@ block content
                 h3
                     strong Lost account / returning player
                 p Creating and operating multiple accounts is prohibited.
-                p If you have a FAF account you can no longer access, please attempt to &nbsp
+                p If you have a FAF account you can no longer access, please attempt to&nbsp;
                     a(
                         href='https://help.steampowered.com/en/wizard/HelpWithLoginInfo?reset=1&issueid=408',
                         target='_blank'

--- a/src/backend/templates/views/account/register.pug
+++ b/src/backend/templates/views/account/register.pug
@@ -14,7 +14,6 @@ block content
                 +flash-messages(flash)
                                 br
                 hr
-                .multipleAccountDisclaimer
                     h3 Lost account / returning player
                     p If you previously had a FAF account you no longer can get access to, please contact the moderation team via discord or forums, or see if you can reset your password using the Steam API. Note that creating and operating multiple accounts is prohibited, and creating a secondary account could lead to moderation action.
 

--- a/src/backend/templates/views/account/register.pug
+++ b/src/backend/templates/views/account/register.pug
@@ -15,8 +15,12 @@ block content
 
                 hr
                 h3 Lost account / returning player
-
-                p If you have a FAF account you can no longer access, please attempt to <a href="https://help.steampowered.com/en/wizard/HelpWithLoginInfo?reset=1&issueid=408" target="_blank">reset your Steam password</a>. For further assistance, contact the moderation team via <a href="https://discord.gg/mXahVSKGVb" target="_blank"/>Discord</a> or the <a href="https://forum.faforever.com/" target="_blank">Forums</a>.
+                p If you have a FAF account you can no longer access, please attempt to &nbsp
+                  a(href="https://help.steampowered.com/en/wizard/HelpWithLoginInfo?reset=1&issueid=408" target="_blank") reset your Steam password.
+                  | &nbspFor further assistance, contact the moderation team via&nbsp
+                  a(href=discordUrl target="_blank") Discord
+                  |  or the&nbsp
+                  a(href=forumUrl target="_blank") Forums.
                 p Creating and operating multiple accounts is prohibited, and creating a secondary account will lead to moderation action.
                 form(
                     method='post',

--- a/src/backend/templates/views/account/register.pug
+++ b/src/backend/templates/views/account/register.pug
@@ -15,8 +15,8 @@ block content
 
                 hr
                 h3 Lost account / returning player
-                p If you previously had a FAF account you no longer can get access to, please contact the moderation team via discord or forums, or see if you can reset your password using the Steam API. Note that creating and operating multiple accounts is prohibited, and creating a secondary account could lead to moderation action.
-
+                p If you have a FAF account you can no longer access, please contact the moderation team via <a href="https://discord.gg/mXahVSKGVb" target="_blank"/>Discord</a> or the <a href="https://forum.faforever.com/" target="_blank">Forums</a>, or attempt to reset your password on <a href="https://help.steampowered.com/en/wizard/HelpWithLoginInfo?reset=1&issueid=408" target="_blank">Steam</a>.
+                p Creating and operating multiple accounts is prohibited, and creating a secondary account will lead to moderation action.
                 form(
                     method='post',
                     action='/account/register',

--- a/src/backend/templates/views/account/register.pug
+++ b/src/backend/templates/views/account/register.pug
@@ -12,6 +12,11 @@ block content
                 h2 Welcome to the FAF community
                 br
                 +flash-messages(flash)
+                                br
+                hr
+                .multipleAccountDisclaimer
+                    h3 Lost account / returning player
+                    p If you previously had a FAF account you no longer can get access to, please contact the moderation team via discord or forums, or see if you can reset your password using the Steam API. Note that creating and operating multiple accounts is prohibited, and creating a secondary account could lead to moderation action.
 
                 form(
                     method='post',

--- a/src/backend/templates/views/account/register.pug
+++ b/src/backend/templates/views/account/register.pug
@@ -15,7 +15,8 @@ block content
 
                 hr
                 h3 Lost account / returning player
-                p If you have a FAF account you can no longer access, please contact the moderation team via <a href="https://discord.gg/mXahVSKGVb" target="_blank"/>Discord</a> or the <a href="https://forum.faforever.com/" target="_blank">Forums</a>, or attempt to reset your password on <a href="https://help.steampowered.com/en/wizard/HelpWithLoginInfo?reset=1&issueid=408" target="_blank">Steam</a>.
+
+                p If you have a FAF account you can no longer access, please attempt to <a href="https://help.steampowered.com/en/wizard/HelpWithLoginInfo?reset=1&issueid=408" target="_blank">reset your Steam password</a>. For further assistance, contact the moderation team via <a href="https://discord.gg/mXahVSKGVb" target="_blank"/>Discord</a> or the <a href="https://forum.faforever.com/" target="_blank">Forums</a>.
                 p Creating and operating multiple accounts is prohibited, and creating a secondary account will lead to moderation action.
                 form(
                     method='post',

--- a/src/backend/templates/views/account/requestPasswordReset.pug
+++ b/src/backend/templates/views/account/requestPasswordReset.pug
@@ -33,11 +33,6 @@ block content
                 br
                 p We will send you an email to your accounts email address containing a link. The link will lead you to a page where you can set your new password.
                 p If you don't receive an email please check your spam folder!
-                p For further assistance, contact the moderation team via&nbsp;
-                    a(href=discordUrl, target='_blank') Discord
-                    |
-                    | or the&nbsp;
-                    a(href=forumUrl, target='_blank') Forums.
                 br
                 .recaptchaForm
                     label.column12
@@ -47,18 +42,18 @@ block content
                         type='submit'
                     ) Reset via email
                     br
-                    br
-
-        br
-        br
-
         .passResetSteam.column12
             h1 Reset password via Steam
             p Click on the button below to get to the Steam login page.
             a(href=steamReset)
                 button Reset via Steam
         br
-        br
+        p If you can't reset your password or regain access to your FAF account via the provided methods above, then please contact the moderation team via&nbsp;
+            a(href=discordUrl, target='_blank') Discord
+            |
+            | or the
+            |
+            a(href=forumUrl, target='_blank') Forums.
 
 block js
     script(src='//www.google.com/recaptcha/api.js')

--- a/src/backend/templates/views/account/requestPasswordReset.pug
+++ b/src/backend/templates/views/account/requestPasswordReset.pug
@@ -7,7 +7,7 @@ block bannerData
     - var bannerSubTitle = ''
 
 block content
-    .passResetContainer
+    .containerCenter
         .flashMessage.column12
             +flash-error(errors)
         .passResetEmail.column12
@@ -33,6 +33,11 @@ block content
                 br
                 p We will send you an email to your accounts email address containing a link. The link will lead you to a page where you can set your new password.
                 p If you don't receive an email please check your spam folder!
+                p For further assistance, contact the moderation team via&nbsp;
+                    a(href=discordUrl, target='_blank') Discord
+                    |
+                    | or the&nbsp;
+                    a(href=forumUrl, target='_blank') Forums.
                 br
                 .recaptchaForm
                     label.column12

--- a/src/backend/templates/views/campaign-missions.pug
+++ b/src/backend/templates/views/campaign-missions.pug
@@ -13,7 +13,7 @@ block content
             p FAF has implemented the co-op feature into the campaign. This means now you can play either of the four original campaigns with up to three friends (four players)! But! That's not all, FAF contributors are also working on creating two new campaigns! One for Seraphim and another one for the coalition! However, be warned that the new campaigns are meant to present a real challenge to seasoned players. If you need some help or have questions, feel free joining the FAF Campaign Development Discord or the FAF Discord!
             a(href='https://discord.gg/ayzAVr9JUV')
                 button Campaign Discord
-            a(href='https://discord.gg/mXahVSKGVb')
+            a(href=discordUrl)
                 button Official Discord
     .mainShowcase
         .showcaseContainer.column6

--- a/src/backend/templates/views/contribution.pug
+++ b/src/backend/templates/views/contribution.pug
@@ -16,7 +16,7 @@ block content
                 h2.highlightText Fixing bugs, killing lag
                 h1 Game development
                 p Want to help fix a game issue? Create your own Co-op mission? Then you can help with development on Github. To start, join our discord so that you can talk with the correct dev and invite you to our Zulip. It is recommended (but not necessary!) knowing some Lua for game developlment, Python for the server work or Java for the FAF client.
-                a(target='_blank', href='https://discord.gg/mXahVSKGVb')
+                a(target='_blank', href=discordUrl)
                     button Join our Discord
                 a(target='_blank', href='https://github.com/faforever/')
                     button FAF repository

--- a/src/backend/templates/views/index.pug
+++ b/src/backend/templates/views/index.pug
@@ -47,9 +47,9 @@ block content
                 h2.highlightText Thriving community
                 h1 Make new friends or foes
                 p Our diverse playerbase makes sure you have a spot in our community. Whether you want to experience surviving against waves of enemy AI, play custom games, rise in the matchmaking ladder or just have fun with friends, FAF has a space for you.
-                a(href='https://discord.gg/kTsxKu52WU')
+                a(href=discordUrl)
                     button Join our Discord
-                a(href='https://forum.faforever.com')
+                a(href=forumUrl)
                     button FAF forums
         .mainShowcase
             .showcaseContainer.column6
@@ -114,5 +114,5 @@ block content
         .bannerContainer.column12
             a(href='/play')
                 button PLAY NOW
-            a(href='https://discord.gg/mXahVSKGVb')
+            a(href=discordUrl)
                 button Join our Discord

--- a/src/backend/templates/views/newshub.pug
+++ b/src/backend/templates/views/newshub.pug
@@ -44,7 +44,7 @@ body
                     .featureLink.featureDiscord.column4
                         a(
                             target='_blank',
-                            href='https://discord.gg/mXahVSKGVb'
+                            href=discordUrl
                         )
                             img(src='/../../images/logos/discord.svg', alt='')
                     .featureLink.featureTwitch.column4
@@ -102,7 +102,7 @@ body
                 ) Community Guides
             .clientMenuContainer.column2
                 ul COMMUNITY
-                a(target='_blank', href='https://forum.faforever.com/') Forums
+                a(target='_blank', href=forumUrl) Forums
                 a(
                     target='_blank',
                     href='https://kazbek.github.io/FAF-Analytics/'

--- a/src/backend/templates/views/newshub.pug
+++ b/src/backend/templates/views/newshub.pug
@@ -42,10 +42,7 @@ body
             .featureSubGrid.column3.featureLink
                 .featureSocial.column12
                     .featureLink.featureDiscord.column4
-                        a(
-                            target='_blank',
-                            href=discordUrl
-                        )
+                        a(target='_blank', href=discordUrl)
                             img(src='/../../images/logos/discord.svg', alt='')
                     .featureLink.featureTwitch.column4
                         a(

--- a/src/backend/templates/views/play.pug
+++ b/src/backend/templates/views/play.pug
@@ -62,9 +62,9 @@ block content
                     button Download FAF
                 br
                 br
-                a(href='https://discord.gg/mXahVSKGVb')
+                a(href=discordUrl)
                     button Discord
-                a(href='https://forum.faforever.com/')
+                a(href=forumUrl)
                     button Forum
                 a(href='https://wiki.faforever.com/en/Play/Linux-Install')
                     button Linux Installation


### PR DESCRIPTION
Adds disclaimer to register page regarding multiple account operation and ownership as well as advise on recovery methods.




<img width="1403" alt="Screenshot 2024-01-11 at 14 57 30" src="https://github.com/FAForever/website/assets/50498548/5a5b5b11-6394-4a9a-a52c-80b2be49b776">

<img src="https://cdn.discordapp.com/attachments/1004800680306954260/1195090931125325904/Screenshot_2024-01-11_at_14.png?ex=65b2ba29&is=65a04529&hm=cd4827e240b2a868cb2aa5f22024f221652bc9c148e0a65b46188d25a1e2c421&" >