### PR TITLE
Increase pill roundness and horizontal padding

### DIFF
--- a/public/styles/abstracts/_mixins.sass
+++ b/public/styles/abstracts/_mixins.sass
@@ -33,7 +33,7 @@
   border: 0px solid variables.$background-secondary
   background-color: variables.$button-inactive
   font-family: variables.$family-subtitle
-  border-radius: 20px
+  border-radius: 9999px
   font-size: 1.5em
   justify-self: center
   transition: 0.4s
@@ -73,33 +73,33 @@
 .landingButton
   font-size: 1.2em
   margin: 0.2em 1em
-  padding: 0.8em
+  padding: 0.8em 1.2em
 @media (max-width: 800px)
   .landingButton
     margin: 8px
     font-size: 14px
-    padding: 0.6em
+    padding: 0.6em 1em
 
 button
   @include button
   font-size: 1em
   margin: 0.2em 1em
-  padding: 0.8em
+  padding: 0.8em 1.2em
 @media (max-width: 800px)
   button
     margin: 0px 8px 8px 8px
     font-size: 12px
-    padding: 0.6em
+    padding: 0.6em 1em
 .smallButton
   @include button
   font-size: 0.75em
   margin: 0.25em
-  padding: 0.5em
+  padding: 0.5em 0.7em
 .bigButton
   @include button
   font-size: 1em
   margin: 0.75em
-  padding: 1em
+  padding: 1em 1.4em
 .descriptionMain
   //background-color: variables.$background-secondary
   padding: 10px

--- a/public/styles/site/newsArticle.sass
+++ b/public/styles/site/newsArticle.sass
@@ -11,7 +11,7 @@
   a
     button
       font-size: 14px
-      padding: 0.5em
+      padding: 0.5em 0.7em
 
 #newsBackground
   background-image: url("../../images/blackasf.jpg")

--- a/public/styles/site/newshub.sass
+++ b/public/styles/site/newshub.sass
@@ -41,7 +41,7 @@
         font-size: 30px
       button
         font-size: 14px
-        padding: 0.5em
+        padding: 0.5em 0.7em
 
     
 @media (max-width: 1200px)
@@ -68,7 +68,7 @@
           font-size: 18px
         button
           font-size: 12px
-          padding: 0.5em
+          padding: 0.5em 0.7em
       .articleImage
 
         padding: 14vw


### PR DESCRIPTION
Hi :wave:

I noticed that the pill buttons on the website in a lot of cases weren't *quite* rounded enough to be a full pill button.

I also increased the horizontal padding on the buttons which I think improves their shape slightly.

| Before                                        | After                                                           |
|-----------------------------------|-----------------------------------------------|
|  ![Before Card](https://github.com/FAForever/website/assets/38820160/0146556e-7566-4fa8-aa1c-ee6ac97b2452) |  ![After Card](https://github.com/FAForever/website/assets/38820160/34f5cc60-9432-4a2a-aceb-a9de869835d2) |
|  ![Before Landing](https://github.com/FAForever/website/assets/38820160/4e87aab3-d89d-4013-87a0-389da38181a3) |  ![After Landing](https://github.com/FAForever/website/assets/38820160/5c63db60-cef7-444e-97b5-505dc725b5d5) |


