### PR TITLE
Update username change instructions, and grammar in bannerSubTitle

### DIFF
--- a/src/backend/templates/views/account/changeUsername.pug
+++ b/src/backend/templates/views/account/changeUsername.pug
@@ -5,7 +5,12 @@ block bannerMixin
 block content
     .containerCenter
         h2.account-title Change Username
-        h4 Change your username by using the form below. Once it is changed, you can log in to your account with the new username. <br> You can only change the name every 30 days and your old username will be reserved for 6 months. <br> In case you choose an offending username you might get banned.
+        h4 Change your username by using the form below. After renaming, you must log out and log back in with the changed username in the FAF Client to access chat.
+        br
+        p You can change your name every 3 months, and your previous username will be reserved for 6 months.
+        br
+        p FAF Rules apply to usernames as well; violations may result in a ban. For more details, please visit
+        a(href='https://faforever.com/rules') the rules.
         br
         .row
             .col-md-offset-3.col-md-6

--- a/src/backend/templates/views/index.pug
+++ b/src/backend/templates/views/index.pug
@@ -3,7 +3,7 @@ block bannerData
     - var bannerImage = 'home'
     - var bannerFirstTitle = 'AN RTS CLASSIC REFORGED'
     - var bannerSecondTitle = 'MASSIVE SCALE WARFARE'
-    - var bannerSubTitle = 'MANY COMMANDERS PLAYING RIGHT NOW'
+    - var bannerSubTitle = 'MANY COMMANDERS ARE PLAYING RIGHT NOW'
 block banner
     mixin banner
         .mainBannerContainer(


### PR DESCRIPTION
This PR Fixes #546 and Fixes #551

Just fixed some minor grammar error, updated the duration-text about renaming, and made clear that the user has to log-out/log-in to make use of FAF Client chat when he changes his username.

If the text should be different, then comment with suggestion, please.

**Note**: I have no web-service running on my dev-machine currently and could not test how it will look rendered.

---

**Edit**: The 551-commit, also Fixes #552; Just saw it now.
