### PR TITLE
Add analytics via Plausible

### DIFF
--- a/src/backend/templates/layouts/default.pug
+++ b/src/backend/templates/layouts/default.pug
@@ -16,7 +16,7 @@ html(lang='en')
         )
 
         //- Analytics via Plausible
-        <script src="https://plausible.io/js/script.js" integrity="sha384-tPOxpLA2/UQKnIkz9xzbWtR4zQVKGeV8UuJKit0l3PQToVtMKtGT9iybQfhxLo+J" crossorigin="anonymous"></script>
+        script src="https://plausible.io/js/script.js" integrity="sha384-tPOxpLA2/UQKnIkz9xzbWtR4zQVKGeV8UuJKit0l3PQToVtMKtGT9iybQfhxLo+J" crossorigin="anonymous" 
 
         // Fonts
         link(

--- a/src/backend/templates/layouts/default.pug
+++ b/src/backend/templates/layouts/default.pug
@@ -17,6 +17,8 @@ html(lang='en')
 
         //- Analytics via Plausible
         script(
+            defer,
+            data-domain='faforever.com',
             src='https://plausible.io/js/script.js',
             integrity='sha384-tPOxpLA2/UQKnIkz9xzbWtR4zQVKGeV8UuJKit0l3PQToVtMKtGT9iybQfhxLo+J',
             crossorigin='anonymous'

--- a/src/backend/templates/layouts/default.pug
+++ b/src/backend/templates/layouts/default.pug
@@ -15,6 +15,9 @@ html(lang='en')
             type='image/png'
         )
 
+        //- Analytics via Plausible
+        <script src="https://plausible.io/js/script.js" integrity="sha384-tPOxpLA2/UQKnIkz9xzbWtR4zQVKGeV8UuJKit0l3PQToVtMKtGT9iybQfhxLo+J" crossorigin="anonymous"></script>
+
         // Fonts
         link(
             href='https://fonts.googleapis.com/css?family=Yanone+Kaffeesatz',

--- a/src/backend/templates/layouts/default.pug
+++ b/src/backend/templates/layouts/default.pug
@@ -16,7 +16,11 @@ html(lang='en')
         )
 
         //- Analytics via Plausible
-        script src="https://plausible.io/js/script.js" integrity="sha384-tPOxpLA2/UQKnIkz9xzbWtR4zQVKGeV8UuJKit0l3PQToVtMKtGT9iybQfhxLo+J" crossorigin="anonymous" 
+        script (
+            src="https://plausible.io/js/script.js" 
+            integrity="sha384-tPOxpLA2/UQKnIkz9xzbWtR4zQVKGeV8UuJKit0l3PQToVtMKtGT9iybQfhxLo+J" 
+            crossorigin="anonymous"
+        )
 
         // Fonts
         link(

--- a/src/backend/templates/layouts/default.pug
+++ b/src/backend/templates/layouts/default.pug
@@ -16,10 +16,10 @@ html(lang='en')
         )
 
         //- Analytics via Plausible
-        script (
-            src="https://plausible.io/js/script.js" 
-            integrity="sha384-tPOxpLA2/UQKnIkz9xzbWtR4zQVKGeV8UuJKit0l3PQToVtMKtGT9iybQfhxLo+J" 
-            crossorigin="anonymous"
+        script(
+            src='https://plausible.io/js/script.js',
+            integrity='sha384-tPOxpLA2/UQKnIkz9xzbWtR4zQVKGeV8UuJKit0l3PQToVtMKtGT9iybQfhxLo+J',
+            crossorigin='anonymous'
         )
 
         // Fonts


### PR DESCRIPTION
Adds a reference to [Plausible](https://plausible.io) to provide privacy-friendly analytics. See also the corresponding dashboard that is public:

- https://plausible.io/faforever.com

Note: the dashboard won't work until this pull request is merged 😄 !

The script tag has a [Subresource integrity hash (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity). This is generated via:

- https://www.srihash.org/

This opens up various interesting capabilities. As an example, in the future we can introduce [funnels](https://plausible.io/docs/funnel-analysis) to see how people experience the onboarding process. 