### PR TITLE
Redirect /news

### DIFF
--- a/src/backend/templates/layouts/default.pug
+++ b/src/backend/templates/layouts/default.pug
@@ -104,7 +104,7 @@ html(lang='en')
                     a(href='/')
                         li.navList HOME
                             ul.navAbsolute
-                    a(href='/news')
+                    a(href='https://news.faforever.com')
                         li.navList NEWS
                             ul.navAbsolute
                     li.navList GAME


### PR DESCRIPTION
to redirect /News to the new https://news.faforever.com/

@Garanas Here is the Main News link on the Website