### PR TITLE
fix(header): Reset Password link broken

### DIFF
--- a/src/backend/templates/layouts/default.pug
+++ b/src/backend/templates/layouts/default.pug
@@ -67,7 +67,7 @@ html(lang='en')
         .mainTopNavContainer
             // this is the "thin" navbar that has forums, discord, youtube icons, etc.
             .topNavContainer
-                a.topnav_item(href='/account/requestPasswordReset') Reset Password
+                a.topnav_item(href=`${userServiceUrl}/recover-account`) Reset Password
             .topNavContainer
                 a.topnav_item(href='/donation') Support FAF
             .topNavContainer


### PR DESCRIPTION
* The 'Reset Password' link points to internal (deleted) route, instead to user service '/recover-account'

**Screenshot:**
<img width="1908" height="604" alt="image" src="https://github.com/user-attachments/assets/00874f50-6cbf-4a0c-92ca-027043081d21" />
